### PR TITLE
Add Ollama-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # litellm-ollama-shim
-A lightweight FastAPI wrapper that adds three Ollama‑compatible endpoints (/api/tags, /api/chat, /api/show) on top of the stock LiteLLM proxy.
+A lightweight FastAPI wrapper that exposes three Ollama‑compatible endpoints
+(`/api/tags`, `/api/chat`, `/api/show`) on top of the stock LiteLLM proxy.
+
+```bash
+uv pip install litellm-ollama-shim
+uvx litellm-ollama-shim  # starts a proxy on port 4000
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,9 @@ litellm-ollama-shim = "litellm_ollama_shim:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.4.0",
+    "ruff>=0.11.13",
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "litellm>=1.72.4",
+    "litellm[proxy]>=1.72.4",
 ]
 
 [project.scripts]

--- a/src/litellm_ollama_shim/__init__.py
+++ b/src/litellm_ollama_shim/__init__.py
@@ -1,5 +1,91 @@
-"""Entry point for litellm-ollama-shim."""
+"""LiteLLM proxy wrapper exposing Ollama compatible routes."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import uuid
+from typing import Any, AsyncGenerator
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+import litellm
+from litellm.proxy.proxy_server import app as _proxy_app
 
 
-def main() -> None:
-    print("hello litellm-ollama-shim")
+def build_app() -> FastAPI:
+    """Return a FastAPI app with added Ollama style endpoints."""
+
+    app: FastAPI = _proxy_app
+    router = APIRouter()
+
+    @router.get("/api/tags")
+    async def tags() -> dict[str, Any]:
+        models = []
+        for m in getattr(app.state, "model_config", []):
+            models.append(
+                {
+                    "name": getattr(m, "display_name", None) or getattr(m, "id", ""),
+                    "model": getattr(m, "id", ""),
+                    "modified_at": _dt.datetime.utcnow().isoformat() + "Z",
+                    "size": 1,
+                    "digest": uuid.uuid4().hex,
+                    "details": {
+                        "family": getattr(m, "family", None) or "custom",
+                        "format": "proxy",
+                        "parameter_size": str(getattr(m, "context_window", "")),
+                    },
+                }
+            )
+        return {"models": models}
+
+    @router.post("/api/chat")
+    async def chat(request: Request) -> Any:
+        body = await request.json()
+        stream = body.get("stream", False)
+
+        async def litestream() -> AsyncGenerator[str, None]:
+            gen = await litellm.acompletion(
+                model=body["model"],
+                messages=body["messages"],
+                stream=True,
+            )
+            async for chunk in gen:
+                content = chunk["choices"][0].get("delta", {}).get("content", "")
+                payload = {"message": {"role": "assistant", "content": content}, "done": False}
+                yield f"data: {json.dumps(payload)}\n\n"
+            yield "data: {\"done\": true}\n\n"
+
+        if stream:
+            return StreamingResponse(litestream(), media_type="text/event-stream")
+
+        completion = await litellm.acompletion(
+            model=body["model"],
+            messages=body["messages"],
+        )
+        content = completion["choices"][0]["message"]["content"]
+        return {"message": {"role": "assistant", "content": content}}
+
+    @router.get("/api/show")
+    async def show(name: str) -> Any:
+        tag_list = (await tags())["models"]
+        for m in tag_list:
+            if m["model"] == name:
+                return m
+        return JSONResponse(status_code=404, content={"error": "model not found"})
+
+    app.include_router(router)
+    return app
+
+
+def main() -> None:  # pragma: no cover - entry point
+    import uvicorn
+
+    uvicorn.run(
+        build_app(),
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", "4000")),
+    )
+

--- a/src/litellm_ollama_shim/__init__.py
+++ b/src/litellm_ollama_shim/__init__.py
@@ -8,11 +8,20 @@ import os
 import uuid
 from typing import Any, AsyncGenerator
 
-from fastapi import APIRouter, FastAPI, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
 
 import litellm
 from litellm.proxy.proxy_server import app as _proxy_app
+
+from .types import (
+    ChatMessage,
+    ChatRequest,
+    ChatResponse,
+    ModelInfo,
+    TagDetails,
+    TagsResponse,
+)
 
 
 def build_app() -> FastAPI:
@@ -21,35 +30,35 @@ def build_app() -> FastAPI:
     app: FastAPI = _proxy_app
     router = APIRouter()
 
-    @router.get("/api/tags")
-    async def tags() -> dict[str, Any]:
+    @router.get("/api/tags", response_model=TagsResponse)
+    async def tags() -> TagsResponse:
         models = []
         for m in getattr(app.state, "model_config", []):
             models.append(
-                {
-                    "name": getattr(m, "display_name", None) or getattr(m, "id", ""),
-                    "model": getattr(m, "id", ""),
-                    "modified_at": _dt.datetime.utcnow().isoformat() + "Z",
-                    "size": 1,
-                    "digest": uuid.uuid4().hex,
-                    "details": {
-                        "family": getattr(m, "family", None) or "custom",
-                        "format": "proxy",
-                        "parameter_size": str(getattr(m, "context_window", "")),
-                    },
-                }
+                ModelInfo(
+                    name=getattr(m, "display_name", None) or getattr(m, "id", ""),
+                    model=getattr(m, "id", ""),
+                    modified_at=_dt.datetime.utcnow(),
+                    size=1,
+                    digest=uuid.uuid4().hex,
+                    details=TagDetails(
+                        family=getattr(m, "family", None) or "custom",
+                        format="proxy",
+                        parameter_size=str(getattr(m, "context_window", "")),
+                    ),
+                )
             )
-        return {"models": models}
+        return TagsResponse(models=models)
 
-    @router.post("/api/chat")
+    @router.post("/api/chat", response_model=ChatResponse)
     async def chat(request: Request) -> Any:
-        body = await request.json()
-        stream = body.get("stream", False)
+        body = ChatRequest(**await request.json())
+        stream = bool(body.stream)
 
         async def litestream() -> AsyncGenerator[str, None]:
             gen = await litellm.acompletion(
-                model=body["model"],
-                messages=body["messages"],
+                model=body.model,
+                messages=[m.model_dump() for m in body.messages],
                 stream=True,
             )
             async for chunk in gen:
@@ -62,19 +71,19 @@ def build_app() -> FastAPI:
             return StreamingResponse(litestream(), media_type="text/event-stream")
 
         completion = await litellm.acompletion(
-            model=body["model"],
-            messages=body["messages"],
+            model=body.model,
+            messages=[m.model_dump() for m in body.messages],
         )
         content = completion["choices"][0]["message"]["content"]
-        return {"message": {"role": "assistant", "content": content}}
+        return ChatResponse(message=ChatMessage(role="assistant", content=content))
 
-    @router.get("/api/show")
-    async def show(name: str) -> Any:
-        tag_list = (await tags())["models"]
+    @router.get("/api/show", response_model=ModelInfo)
+    async def show(name: str) -> ModelInfo:
+        tag_list = (await tags()).models
         for m in tag_list:
-            if m["model"] == name:
+            if m.model == name:
                 return m
-        return JSONResponse(status_code=404, content={"error": "model not found"})
+        raise HTTPException(status_code=404, detail="model not found")
 
     app.include_router(router)
     return app

--- a/src/litellm_ollama_shim/types.py
+++ b/src/litellm_ollama_shim/types.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class TagDetails(BaseModel):
+    family: str
+    format: str
+    parameter_size: str
+
+
+class ModelInfo(BaseModel):
+    name: str
+    model: str
+    modified_at: datetime
+    size: int
+    digest: str
+    details: TagDetails
+
+
+class TagsResponse(BaseModel):
+    models: List[ModelInfo]
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: List[ChatMessage]
+    stream: Optional[bool] = False
+
+
+class ChatResponse(BaseModel):
+    message: ChatMessage
+

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,61 @@
+from fastapi.testclient import TestClient
+
+import litellm_ollama_shim as shim
+
+class DummyModel:
+    def __init__(self, id, display_name=None, family=None, context_window=0):
+        self.id = id
+        self.display_name = display_name
+        self.family = family
+        self.context_window = context_window
+
+def build_client(monkeypatch):
+    app = shim.build_app()
+    app.state.model_config = [
+        DummyModel("foo", display_name="Foo Model", family="llama", context_window=2048)
+    ]
+
+    async def fake_acompletion(**kwargs):
+        if kwargs.get("stream"):
+            async def gen():
+                yield {"choices": [{"delta": {"content": "hi"}}]}
+                yield {"choices": [{}]}
+            return gen()
+        return {"choices": [{"message": {"content": "hi"}}]}
+
+    monkeypatch.setattr(shim.litellm, "acompletion", fake_acompletion)
+    return TestClient(app)
+
+def test_tags(monkeypatch):
+    client = build_client(monkeypatch)
+    resp = client.get("/api/tags")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["models"][0]["model"] == "foo"
+    assert data["models"][0]["name"] == "Foo Model"
+
+def test_chat(monkeypatch):
+    client = build_client(monkeypatch)
+    resp = client.post(
+        "/api/chat",
+        json={"model": "foo", "messages": [{"role": "user", "content": "?"}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["message"]["content"] == "hi"
+
+
+def test_chat_stream(monkeypatch):
+    client = build_client(monkeypatch)
+    resp = client.post(
+        "/api/chat",
+        json={"model": "foo", "messages": [{"role": "user", "content": "?"}], "stream": True},
+    )
+    chunks = list(resp.iter_lines())
+    assert any("data:" in c for c in chunks)
+
+
+def test_show(monkeypatch):
+    client = build_client(monkeypatch)
+    resp = client.get("/api/show", params={"name": "foo"})
+    assert resp.status_code == 200
+    assert resp.json()["model"] == "foo"

--- a/uv.lock
+++ b/uv.lock
@@ -351,6 +351,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -467,8 +476,20 @@ dependencies = [
     { name = "litellm" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "litellm", specifier = ">=1.72.4" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "ruff", specifier = ">=0.11.13" },
+]
 
 [[package]]
 name = "markupsafe"
@@ -597,6 +618,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +738,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
 ]
 
 [[package]]
@@ -859,6 +914,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/ab/e04bf58a8d375aeedb5268edcc835c6a660ebf79d4384d8e0889439448b0/rpds_py-0.25.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58f77c60956501a4a627749a6dcb78dac522f249dd96b5c9f1c6af29bfacfb66", size = 558891, upload-time = "2025-05-21T12:44:37.358Z" },
     { url = "https://files.pythonhosted.org/packages/90/82/cb8c6028a6ef6cd2b7991e2e4ced01c854b6236ecf51e81b64b569c43d73/rpds_py-0.25.1-cp313-cp313t-win32.whl", hash = "sha256:2cb9e5b5e26fc02c8a4345048cd9998c2aca7c2712bd1b36da0c72ee969a3523", size = 218718, upload-time = "2025-05-21T12:44:38.969Z" },
     { url = "https://files.pythonhosted.org/packages/b6/97/5a4b59697111c89477d20ba8a44df9ca16b41e737fa569d5ae8bff99e650/rpds_py-0.25.1-cp313-cp313t-win_amd64.whl", hash = "sha256:401ca1c4a20cc0510d3435d89c069fe0a9ae2ee6495135ac46bdd49ec0495763", size = 232218, upload-time = "2025-05-21T12:44:40.512Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/da/9c6f995903b4d9474b39da91d2d626659af3ff1eeb43e9ae7c119349dba6/ruff-0.11.13.tar.gz", hash = "sha256:26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514", size = 4282054, upload-time = "2025-06-05T21:00:15.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ce/a11d381192966e0b4290842cc8d4fac7dc9214ddf627c11c1afff87da29b/ruff-0.11.13-py3-none-linux_armv6l.whl", hash = "sha256:4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46", size = 10292516, upload-time = "2025-06-05T20:59:32.944Z" },
+    { url = "https://files.pythonhosted.org/packages/78/db/87c3b59b0d4e753e40b6a3b4a2642dfd1dcaefbff121ddc64d6c8b47ba00/ruff-0.11.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48", size = 11106083, upload-time = "2025-06-05T20:59:37.03Z" },
+    { url = "https://files.pythonhosted.org/packages/77/79/d8cec175856ff810a19825d09ce700265f905c643c69f45d2b737e4a470a/ruff-0.11.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b", size = 10436024, upload-time = "2025-06-05T20:59:39.741Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5b/f6d94f2980fa1ee854b41568368a2e1252681b9238ab2895e133d303538f/ruff-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a", size = 10646324, upload-time = "2025-06-05T20:59:42.185Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/b4c2acf24ea4426016d511dfdc787f4ce1ceb835f3c5fbdbcb32b1c63bda/ruff-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc", size = 10174416, upload-time = "2025-06-05T20:59:44.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/10/e2e62f77c65ede8cd032c2ca39c41f48feabedb6e282bfd6073d81bb671d/ruff-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629", size = 11724197, upload-time = "2025-06-05T20:59:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f0/466fe8469b85c561e081d798c45f8a1d21e0b4a5ef795a1d7f1a9a9ec182/ruff-0.11.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933", size = 12511615, upload-time = "2025-06-05T20:59:49.534Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0e/cefe778b46dbd0cbcb03a839946c8f80a06f7968eb298aa4d1a4293f3448/ruff-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165", size = 12117080, upload-time = "2025-06-05T20:59:51.654Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2c/caaeda564cbe103bed145ea557cb86795b18651b0f6b3ff6a10e84e5a33f/ruff-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71", size = 11326315, upload-time = "2025-06-05T20:59:54.469Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/782e7d681d660eda8c536962920c41309e6dd4ebcea9a2714ed5127d44bd/ruff-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9", size = 11555640, upload-time = "2025-06-05T20:59:56.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d4/3d580c616316c7f07fb3c99dbecfe01fbaea7b6fd9a82b801e72e5de742a/ruff-0.11.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc", size = 10507364, upload-time = "2025-06-05T20:59:59.154Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/dc/195e6f17d7b3ea6b12dc4f3e9de575db7983db187c378d44606e5d503319/ruff-0.11.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7", size = 10141462, upload-time = "2025-06-05T21:00:01.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8e/39a094af6967faa57ecdeacb91bedfb232474ff8c3d20f16a5514e6b3534/ruff-0.11.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432", size = 11121028, upload-time = "2025-06-05T21:00:04.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c0/b0b508193b0e8a1654ec683ebab18d309861f8bd64e3a2f9648b80d392cb/ruff-0.11.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492", size = 11602992, upload-time = "2025-06-05T21:00:06.249Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944, upload-time = "2025-06-05T21:00:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669, upload-time = "2025-06-05T21:00:11.147Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928, upload-time = "2025-06-05T21:00:13.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- wrap LiteLLM proxy to serve `/api/tags`, `/api/chat`, `/api/show`
- document simple usage
- add ruff dev dependency and update instructions
- add pytest and basic translation tests

## Testing
- `pip check`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cb352543083248ed5b9a83c248adc