### PR TITLE
Add Ruff config and auto format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,33 @@ dev = [
     "ruff>=0.11.13",
 ]
 
+
+[tool.ruff.lint]
+select = [
+  "E",        # full pycodestyle (superset of E4/E7/E9)
+  "F",        # Pyflakes
+
+  # Code-correctness & modernization
+  "B",        # flake8-bugbear  – probable bugs & foot-guns
+  "UP",       # pyupgrade       – auto-modernise to the minimum Python
+  "SIM",      # flake8-simplify – flag pointless constructs
+
+  # Hygiene & consistency
+  "I",        # isort           – deterministic import order
+  "RUF",      # Ruff-specific   – incl. RUF100 (unused noqa)
+
+  # Optional-but-useful extras
+  "ARG",      # flake8-unused-arguments – dead params
+  "S",        # flake8-bandit   – basic security checks
+  "N",        # pep8-naming     – function/class naming
+  "D",        # pydocstyle      – docstring conventions
+]
+
+# Treat line length as a formatter concern
+ignore = ["E501"]
+
+# Silence deliberate re-exports
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*" = ["S101"]
+

--- a/src/litellm_ollama_shim/__main__.py
+++ b/src/litellm_ollama_shim/__main__.py
@@ -1,3 +1,5 @@
+"""Entry point for running the shim as a module."""
+
 from . import main
 
 if __name__ == "__main__":

--- a/src/litellm_ollama_shim/types.py
+++ b/src/litellm_ollama_shim/types.py
@@ -1,18 +1,23 @@
+"""Pydantic models representing Ollama-style API schemas."""
+
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
 
 from pydantic import BaseModel
 
 
 class TagDetails(BaseModel):
+    """Metadata for a model tag."""
+
     family: str
     format: str
     parameter_size: str
 
 
 class Tag(BaseModel):
+    """Information about an available model."""
+
     name: str
     model: str
     modified_at: datetime
@@ -22,26 +27,36 @@ class Tag(BaseModel):
 
 
 class TagsResponse(BaseModel):
-    models: List[Tag]
+    """Response payload for the `/api/tags` endpoint."""
+
+    models: list[Tag]
 
 
 class ChatMessage(BaseModel):
+    """One message in a conversation."""
+
     role: str
     content: str
 
 
 class ChatRequest(BaseModel):
+    """Request payload for the `/api/chat` endpoint."""
+
     model: str
-    messages: List[ChatMessage]
+    messages: list[ChatMessage]
     stream: bool = False
 
 
 class ChatResponseMessage(BaseModel):
+    """Chat completion message returned by the model."""
+
     role: str
     content: str
 
 
 class ChatResponse(BaseModel):
+    """Response payload for non-streaming chat completions."""
+
     message: ChatResponseMessage
 
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,17 +1,25 @@
+"""Tests for translation between LiteLLM and Ollama APIs."""
+
 from fastapi.testclient import TestClient
 
 import litellm_ollama_shim as shim
 from litellm_ollama_shim import types
 from litellm_ollama_shim.types import ChatRequest, TagsResponse
 
+
 class DummyModel:
+    """Minimal stub to simulate a LiteLLM model config."""
+
     def __init__(self, id, display_name=None, family=None, context_window=0):
+        """Store attributes used by the shim during tests."""
         self.id = id
         self.display_name = display_name
         self.family = family
         self.context_window = context_window
 
+
 def build_client(monkeypatch):
+    """Return a TestClient with patched LiteLLM completion."""
     app = shim.build_app()
     app.state.model_config = [
         DummyModel("foo", display_name="Foo Model", family="llama", context_window=2048)
@@ -19,16 +27,20 @@ def build_client(monkeypatch):
 
     async def fake_acompletion(**kwargs):
         if kwargs.get("stream"):
+
             async def gen():
                 yield {"choices": [{"delta": {"content": "hi"}}]}
                 yield {"choices": [{}]}
+
             return gen()
         return {"choices": [{"message": {"content": "hi"}}]}
 
     monkeypatch.setattr(shim.litellm, "acompletion", fake_acompletion)
     return TestClient(app)
 
+
 def test_tags(monkeypatch):
+    """`/api/tags` should return available models."""
     client = build_client(monkeypatch)
     resp = client.get("/api/tags")
     assert resp.status_code == 200
@@ -36,28 +48,36 @@ def test_tags(monkeypatch):
     assert data.models[0].model == "foo"
     assert data.models[0].name == "Foo Model"
 
+
 def test_chat(monkeypatch):
+    """Non-streaming chat endpoint should return a full message."""
     client = build_client(monkeypatch)
     resp = client.post(
         "/api/chat",
-        json=ChatRequest(model="foo", messages=[{"role": "user", "content": "?"}]).model_dump(),
+        json=ChatRequest(
+            model="foo", messages=[{"role": "user", "content": "?"}]
+        ).model_dump(),
     )
     assert resp.status_code == 200
     assert resp.json()["message"]["content"] == "hi"
 
 
 def test_chat_stream(monkeypatch):
+    """Streaming chat endpoint should yield chunks."""
     client = build_client(monkeypatch)
     resp = client.post(
         "/api/chat",
-        json=ChatRequest(model="foo", messages=[{"role": "user", "content": "?"}], stream=True).model_dump(),
+        json=ChatRequest(
+            model="foo", messages=[{"role": "user", "content": "?"}], stream=True
+        ).model_dump(),
     )
     chunks = list(resp.iter_lines())
     assert any("data:" in c for c in chunks)
-    assert "data: {\"done\": true}" in chunks[-2]
+    assert 'data: {"done": true}' in chunks[-2]
 
 
 def test_show(monkeypatch):
+    """`/api/show` should look up a model by name."""
     client = build_client(monkeypatch)
     resp = client.get("/api/show", params={"name": "foo"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- configure Ruff in `pyproject.toml`
- add missing docstrings and ignore Bandit assert rule in tests
- run `ruff --fix` and `ruff format` to apply style fixes

## Testing
- `uvx ruff check --fix && uvx ruff format`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d312260408324a3b15805fc862591